### PR TITLE
allow peeking for exceptions in void future_queues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ cmake_minimum_required(VERSION 2.8)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
 set(${PROJECT_NAME}_MAJOR_VERSION 01)
-set(${PROJECT_NAME}_MINOR_VERSION 03)
-set(${PROJECT_NAME}_PATCH_VERSION 03)
+set(${PROJECT_NAME}_MINOR_VERSION 04)
+set(${PROJECT_NAME}_PATCH_VERSION 00)
 include(cmake/set_version_numbers.cmake)
 
 # find BOOST libraries (needed for tests only)

--- a/include/future_queue.hpp
+++ b/include/future_queue.hpp
@@ -303,6 +303,10 @@ namespace cppext {
         typename std::enable_if<std::is_same<T, U>::value && !std::is_same<U, void>::value, int>::type = 0>
     U& front();
 
+    template<typename U = T,
+        typename std::enable_if<std::is_same<T, U>::value && std::is_same<U, void>::value, int>::type = 0>
+    void front() const;
+
     /** Add continuation: Whenever there is a new element in the queue, process it
      * with the callable and put the result into a new queue. The new queue will
      * be returned by this function.
@@ -1175,6 +1179,14 @@ namespace cppext {
     assert(d->hasFrontOwnership);
     if(d->exceptions[d->readIndex % d->nBuffers]) std::rethrow_exception(d->exceptions[d->readIndex % d->nBuffers]);
     return future_queue_base::d.cast<T>()->buffers[d->readIndex % d->nBuffers];
+  }
+
+  /** This front() is for void data types */
+  template<typename T, typename FEATURES>
+  template<typename U, typename std::enable_if<std::is_same<T, U>::value && std::is_same<U, void>::value, int>::type>
+  void future_queue<T, FEATURES>::front() const {
+    assert(d->hasFrontOwnership);
+    if(d->exceptions[d->readIndex % d->nBuffers]) std::rethrow_exception(d->exceptions[d->readIndex % d->nBuffers]);
   }
 
   /*********************************************************************************************************************/


### PR DESCRIPTION
This is needed for the DeviceAccess ReadAnyGroup, to simplify the implementation.