### PR TITLE
Initialize std::atomic<when_any_notification_info>

### DIFF
--- a/include/future_queue.hpp
+++ b/include/future_queue.hpp
@@ -420,7 +420,7 @@ namespace cppext {
        * will point to the original queue of which *this is the continuation. */
       future_queue_base continuation_origin;
 
-      std::atomic<when_any_notification_info> when_any_notification;
+      std::atomic<when_any_notification_info> when_any_notification{when_any_notification_info()};
     };
 
     /** Internal class for holding the data which is shared between multiple


### PR DESCRIPTION
Before C++ 20, the default constructor of `std::atomic` does not initialize the underlying object (see https://en.cppreference.com/w/cpp/atomic/atomic/atomic). This can lead to situations where `load()` returns an uninitialized object, thus resulting in undefined behavior.

This PR fixes #16.