### PR TITLE
Fixed direct memory leak reported in testAsyncRead by renovating shar…

### DIFF
--- a/include/future_queue.hpp
+++ b/include/future_queue.hpp
@@ -356,6 +356,8 @@ namespace cppext {
        * called. */
       virtual ~shared_state_base() {}
 
+      inline void free(); // added during Feb 2023 Focus.
+
       /** reference count. See shared_state_ptr for further documentation. */
       std::atomic<size_t> reference_count{0};
 
@@ -439,6 +441,77 @@ namespace cppext {
     struct shared_state<void> : shared_state_base {
       shared_state(size_t length) : shared_state_base(length) {}
     };
+
+    inline void shared_state_base::free() {
+      // Reduce reference count but atomically keep the old reference counter. Note
+      // that the std::memory_order_relaxed refers to the access to the pointer not
+      // to the reference counter.
+      size_t oldCount = this->reference_count--;
+
+      // Determine whether we need to destroy the shared state depending on possible
+      // internal references.
+      bool executeDelete = false;
+
+      // Standard case: no continuation. If the last user is just destroying its
+      // reference we delete the shared state.
+      if(oldCount == 1 && !this->is_continuation_async && !this->is_continuation_deferred &&
+          !this->is_continuation_when_all) {
+        executeDelete = true;
+      }
+      // Deferred continuations (incl. when_all) have two internal use counts due to
+      // the two std::functions, so we need to remove those functions first.
+      else if(oldCount == 3 && (this->is_continuation_deferred || this->is_continuation_when_all)) {
+        this->continuation_process_deferred = {};
+        this->continuation_process_deferred_wait = {};
+        executeDelete = true;
+      }
+      // Async continuations have one internal use count inside their thread, so we
+      // need to terminate the thread first.
+      else if(oldCount == 2 && this->is_continuation_async) {
+        if(this->continuation_process_async.joinable()) {
+          // Signal termination to internal thread and wait until thread has been
+          // terminated
+          while(this->continuation_process_async_terminated == false) {
+            // Push a detail::TerminateInternalThread exception into the queue which
+            // the internal thread is potentially waiting on.
+            try {
+              throw detail::TerminateInternalThread();
+            }
+            catch(...) {
+              // Special case: the origin queue is a continuation itself (deferred
+              // or when_all) - we need to push the exception to the origin of the
+              // origin to actually reach the internal thread, since
+              // deferred/when_all continuations do not really use their own queue
+              if(this->continuation_origin.d->is_continuation_deferred ||
+                  this->continuation_origin.d->is_continuation_when_all) {
+                this->continuation_origin.d->continuation_origin.push_exception(std::current_exception());
+              }
+              // Standard case: just push the exception to the origin queue of the
+              // continuation
+              else {
+                this->continuation_origin.push_exception(std::current_exception());
+              }
+            } // end catch
+          }   // end while
+
+          this->continuation_process_async.join();
+        }
+        // end else branch 3.else
+        executeDelete = true;
+      } // end branch 3
+
+      // delete the shared_state?
+      if(executeDelete) {
+        // Now that all potential internal references have been cleared the
+        // reference count must be 0
+        assert(reference_count == 0);
+        if(when_any_notification.load().notifyerQueue) {
+          when_any_notification.load().notifyerQueue->free();
+        }
+        delete this;
+      } // end if executeDelete
+
+    } // end shared_state_base::free()
 
   } // namespace detail
 
@@ -613,71 +686,12 @@ namespace cppext {
     inline void shared_state_ptr::free() {
       // Don't do anything if called on a nullptr (i.e. default constructed or
       // already destroyed)
-      if(get() == nullptr) return;
-
-      // Reduce reference count but atomically keep the old reference counter. Note
-      // that the std::memory_order_relaxed refers to the access to the pointer not
-      // to the reference counter.
-      size_t oldCount = get()->reference_count--;
-
-      // Determine whether we need to destroy the shared state depending on possible
-      // internal references.
-      bool executeDelete = false;
-
-      // Standard case: no continuation. If the last user is just destroying its
-      // reference we delete the shared state.
-      if(oldCount == 1 && !get()->is_continuation_async && !get()->is_continuation_deferred &&
-          !get()->is_continuation_when_all) {
-        executeDelete = true;
-      }
-      // Deferred continuations (incl. when_all) have two internal use counts due to
-      // the two std::functions, so we need to remove those functions first.
-      else if(oldCount == 3 && (get()->is_continuation_deferred || get()->is_continuation_when_all)) {
-        get()->continuation_process_deferred = {};
-        get()->continuation_process_deferred_wait = {};
-        executeDelete = true;
-      }
-      // Async continuations have one internal use count inside their thread, so we
-      // need to terminate the thread first.
-      else if(oldCount == 2 && get()->is_continuation_async) {
-        if(get()->continuation_process_async.joinable()) {
-          // Signal termination to internal thread and wait until thread has been
-          // terminated
-          while(get()->continuation_process_async_terminated == false) {
-            // Push a detail::TerminateInternalThread exception into the queue which
-            // the internal thread is potentially waiting on.
-            try {
-              throw detail::TerminateInternalThread();
-            }
-            catch(...) {
-              // Special case: the origin queue is a continuation itself (deferred
-              // or when_all) - we need to push the exception to the origin of the
-              // origin to actually reach the internal thread, since
-              // deferred/when_all continuations do not really use their own queue
-              if(get()->continuation_origin.d->is_continuation_deferred ||
-                  get()->continuation_origin.d->is_continuation_when_all) {
-                get()->continuation_origin.d->continuation_origin.push_exception(std::current_exception());
-              }
-              // Standard case: just push the exception to the origin queue of the
-              // continuation
-              else {
-                get()->continuation_origin.push_exception(std::current_exception());
-              }
-            }
-          }
-          get()->continuation_process_async.join();
-        }
-        executeDelete = true;
+      if(get() == nullptr) {
+        return;
       }
 
-      // delete the shared_state?
-      if(executeDelete) {
-        // Now that all potential internal references have been cleared the
-        // reference count must be 0
-        assert(get()->reference_count == 0);
-        delete get();
-        set(nullptr);
-      }
+      get()->free();
+      set(nullptr);
     }
 
     template<typename T>


### PR DESCRIPTION
…ed_state_ptr::free() and creating shared_state_base::free() in future_queue.hpp. Functions  affected by this include future_queue_base::setNotificationQueue(), and when_any().