### PR TITLE
fix: race condition

### DIFF
--- a/include/future_queue.hpp
+++ b/include/future_queue.hpp
@@ -369,7 +369,7 @@ namespace cppext {
       std::atomic<size_t> reference_count{0};
 
       /** index used in wait_any to identify the queue */
-      size_t when_any_index;
+      std::atomic<size_t> when_any_index;
 
       /** the number of buffers we have allocated */
       size_t nBuffers;


### PR DESCRIPTION
When creating the notification queue in when_any() while the sending thread is already active, the when_any_index was written and read concurrently, but neither atomic nor protected by a mutex or memory barrier.